### PR TITLE
Implement full wrapper around ioredis constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,18 @@ This package is still under development and APIs are subject to frequent changes
 
 ## Basic Usage
 
-Create a Redis storage schema:
+Create a zod-redis instance using the same constructor as ioredis:
 
 ```typescript
-const zredis = new ZRedis(new Redis(), {
-  birthday: {
-    zod: z.date(),
-    getKey: <T extends string>(userId: T) => `birthday:${userId}` as const,
-    expirationSeconds: 30,
+const zredis = new ZRedis(6379, "127.0.0.1", {
+  schema: {
+    birthday: {
+      zod: z.date(),
+      getKey: <T extends string>(userId: T) => {
+        return `birthday:${userId}` as const;
+      },
+      expirationSeconds: 30,
+    },
   },
 });
 ```

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,14 +1,25 @@
-import Redis from "ioredis";
-import { ZRedis } from "../src/index";
+import { Schema, ZRedis } from "../src/index";
 import { z } from "zod";
 
-const zredis = new ZRedis(new Redis(), {
+const schema = {
   birthday: {
     zod: z.date(),
-    getKey: <T extends string>(userId: T) => `birthday:${userId}` as const,
+    getKey: <T extends string>(userId: T) => {
+      return `birthday:${userId}` as const;
+    },
     expirationSeconds: 30,
   },
-});
+} satisfies Schema;
+
+/**
+ * Test behavior of standard Redis functions for comparison
+ */
+// const redis = new Redis(6380);
+// await redis.set("birthday:12345", "test");
+// const result = await redis.get("birthday:12345");
+// console.log(result);
+
+const zredis = new ZRedis(6379, "127.0.0.1", { schema });
 
 const birthdayKey = zredis.model("birthday").getKey("12345");
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
-    "ioredis": "^5.3.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -33,6 +32,7 @@
     "typescript": "4.9.4"
   },
   "dependencies": {
+    "ioredis": "^5.3.2",
     "superjson": "^1.13.3"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,18 @@
+import { RedisOptions } from "ioredis";
+import { z } from "zod";
+import { ZodTypeAny } from "zod";
+
+export type SchemaModel = {
+  zod: ZodTypeAny;
+  getKey: (...args: any[]) => string;
+  expirationSeconds?: number;
+};
+export type Schema = Record<string, SchemaModel>;
+
+export type ModelName<TSchema extends Schema> = keyof TSchema;
+export type Key<TModel extends SchemaModel> = ReturnType<TModel["getKey"]>;
+export type Value<TModel extends SchemaModel> = z.infer<TModel["zod"]>;
+
+export type ZRedisOptions<TSchema extends Schema> = RedisOptions & {
+  schema?: TSchema;
+};


### PR DESCRIPTION
This PR adds full compatibility to ioredis's constructor, meaning you no longer need to construct it directly and pass it in as an argument to zod-redis's constructor.

This PR also makes ioredis a dependency rather than a peerDependency. This is in light of a focused direction towards becoming a full wrapper around ioredis, with an end goal of replacing the need to access it directly. Since it is an incomplete wrapper currently, I'm considering exposing the ioredis internal property to be used when functionality isn't supported through zod-redis.